### PR TITLE
Delete spare `proc-multi-ubuntu-label`.

### DIFF
--- a/docs/source/sysadmin_guide/about_dynamic_consensus.rst
+++ b/docs/source/sysadmin_guide/about_dynamic_consensus.rst
@@ -112,7 +112,7 @@ submit a consensus change proposal.
 
 #. If a new node joins the network, it must run both consensus engines and all
    related transaction processors. The original consensus is required to process
-   the first set of blocks.
+   the blocks that were submitted using the previous consensus.
 
 
 .. _pbft-consensus-label:

--- a/docs/source/sysadmin_guide/grafana_configuration.rst
+++ b/docs/source/sysadmin_guide/grafana_configuration.rst
@@ -248,7 +248,7 @@ the REST API settings for Grafana.
    * To restart ``sawtooth-rest-api`` on the command line, see the appropriate
      procedure in the Application Developer's Guide: either
      :doc:`../app_developers_guide/ubuntu` or :ref:`proc-multi-ubuntu-label`.
-     :ref:`proc-multi-ubuntu-label`.
+     
 
 
 Configure Telegraf


### PR DESCRIPTION
Signed-off-by: Hans Jin hans_jin@126.com
Delete spare sentence, :ref:`proc-multi-ubuntu-label`